### PR TITLE
Change beta to zero

### DIFF
--- a/examples/oemof_0.2/generic_chp/bpt.py
+++ b/examples/oemof_0.2/generic_chp/bpt.py
@@ -71,7 +71,7 @@ bpt = solph.components.GenericCHP(
         Eta_el_min_woDH=[0.43 for p in range(0, periods)])},
     heat_output={bth: solph.Flow(
         Q_CW_min=[0 for p in range(0, periods)])},
-    Beta=[0.19 for p in range(0, periods)],
+    Beta=[0. for p in range(0, periods)],
     back_pressure=True)
 # create an optimization problem and solve it
 om = solph.Model(es)


### PR DESCRIPTION
The example on the backpressure turbine has been adapted by setting beta to zero. A power loss factor has no actual meaning in a backpressure turbine where the heat/power ratio is fixed. However, beta is one of the factors that has to be given to instantiate a GenericCHP. 

To make things easier, it should be set to zero, so P_max_woDH or P_min_woDH is the same as the maximal power production or minimal power production respectively.

Compare with [PR 525](https://github.com/oemof/oemof/pull/525)